### PR TITLE
Did not work for me, now it does

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Other tweaks have been made to the configuration to make it more suitable for te
 
 These should be locked down to trusted hosts if using these techniques in production.
 
+If you want to use Hiera, place your config in puppet/hieradata and uncomment the resource handling hiera.yaml in VagrantConf/manifests/default.pp, editing both as necessary.
+
 ###Puppet Dashboard
 
 The Dashboard can be accessed at [http://192.168.33.10:3000](http://192.168.33.10:3000). This also runs using webbrick, which makes it unsuitable for a large scale deployment.

--- a/VagrantConf/manifests/default.pp
+++ b/VagrantConf/manifests/default.pp
@@ -11,16 +11,16 @@ node default {
 
   
   package {'puppetmaster':
-    ensure  =>  latest,
+    ensure  => latest,
     require => Host['puppet.grahamgilbert.dev'],
   }
     
   # Configure puppetdb and its underlying database
   class { 'puppetdb': 
-    listen_address => '0.0.0.0',
-    require => Package['puppetmaster'],
+    listen_address    => '0.0.0.0',
+    require           => Package['puppetmaster'],
     database          => 'embedded',
-    puppetdb_version => latest,
+    puppetdb_version  => latest,
     }
   # Configure the puppet master to use puppetdb
   class { 'puppetdb::master::config': }
@@ -75,6 +75,7 @@ node default {
     recurse => true,
   }
   
+/*
   file { '/etc/puppet/hiera.yaml':
     ensure => link,
     owner => root,
@@ -82,7 +83,8 @@ node default {
     source => "/vagrant/puppet/hiera.yaml",
     notify  =>  [Service['puppetmaster'],Service['puppet-dashboard']],
   }
-  
+*/
+
   file { '/etc/puppet/hieradata':
     mode => '0644',
     recurse => true,


### PR DESCRIPTION
Hi,
running your code gave me errors on missing escaping for mysql user/group, so I changed that to something without problems.
I am not using Hiera at this time and your hiera.yaml gave me problems on later runs, so I disabled that.
Why set up two SQL-Servers for testing? Puppet-Dashboard needs MySQL ok, but puppetdb can use an embedded db. No need for Postgres here.
Regards from Munich
Jochen
