### PR TITLE
Lock down version of mysql module

### DIFF
--- a/VagrantConf/Puppetfile
+++ b/VagrantConf/Puppetfile
@@ -18,7 +18,7 @@ mod 'puppetlabs/firewall'
 
 mod 'puppetlabs/inifile'
 
-mod 'puppetlabs/mysql'
+mod 'puppetlabs/mysql', '2.3.0'
 
 mod 'puppetlabs/passenger'
 


### PR DESCRIPTION
# This locks down the puppetlabs/mysql module to version 2.3.0

The update of the module caused the `dashboard-user` username to fail, because the `-` is now classified as an illegal character if it is passed into the mysql_user class unquoted.
